### PR TITLE
feat: 예매 관련 Entity 클래스 추가

### DIFF
--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/PerformanceSeat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/PerformanceSeat.java
@@ -1,6 +1,7 @@
 package com.showhive.performance.domain;
 
 import com.showhive.BaseEntity;
+import com.showhive.code.domain.Code;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,16 +13,18 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Table(name = "performance_seats")
 @Entity
 @Getter
-@Table(name = "performance_seats")
-@AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class PerformanceSeat extends BaseEntity {
 
     @Id
@@ -29,19 +32,17 @@ public class PerformanceSeat extends BaseEntity {
     @Column(name = "performance_seat_id")
     private Long id;
 
-// TODO: PerformanceSession 연결
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "session_id")
-//    private PerformanceSession performanceSession;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private PerformanceSession performanceSession;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seat_id")
     private Seat seat;
 
-// TODO: Code 연결
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "code_id")
-//    private Code seatStatusCode;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "code_id")
+    private Code seatStatusCode;
 
     private int price;
 

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/PerformanceSeat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/PerformanceSeat.java
@@ -1,0 +1,47 @@
+package com.showhive.performance.domain;
+
+import com.showhive.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "performance_seats")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PerformanceSeat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+// TODO: PerformanceSession 연결
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "session_id")
+//    private PerformanceSession performanceSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
+
+// TODO: Code 연결
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "code_id")
+//    private Code seatStatusCode;
+
+    private int price;
+
+    private LocalDateTime holdExpiresAt;
+}

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/PerformanceSeat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/PerformanceSeat.java
@@ -1,6 +1,7 @@
 package com.showhive.performance.domain;
 
 import com.showhive.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -25,6 +26,7 @@ public class PerformanceSeat extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "performance_seat_id")
     private Long id;
 
 // TODO: PerformanceSession 연결

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
@@ -1,0 +1,44 @@
+package com.showhive.performance.domain;
+
+import com.showhive.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "seats")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id")
+    private Venue venue;
+
+    @Column(name = "`column`")
+    private String column;
+
+    @Column(name = "`row`")
+    private Integer row;
+
+    private Integer floor;
+
+    @NotBlank
+    private String seatType;
+}

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
@@ -25,6 +25,7 @@ public class Seat extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seat_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
@@ -32,13 +32,11 @@ public class Seat extends BaseEntity {
     @JoinColumn(name = "venue_id")
     private Venue venue;
 
-    @Column(name = "`column`")
-    private String column;
+    private String seatColumn;
 
-    @Column(name = "`row`")
-    private Integer row;
+    private Integer seatRow;
 
-    private Integer floor;
+    private Integer seatFloor;
 
     @NotBlank
     private String seatType;

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
@@ -34,9 +34,9 @@ public class Seat extends BaseEntity {
 
     private String seatColumn;
 
-    private Integer seatRow;
+    private Short seatRow;
 
-    private Integer seatFloor;
+    private Short seatFloor;
 
     @NotBlank
     private String seatType;

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Seat.java
@@ -13,14 +13,16 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(name = "seats")
 @Entity
 @Getter
-@Table(name = "seats")
-@AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Seat extends BaseEntity {
 
     @Id

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Venue.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Venue.java
@@ -1,6 +1,7 @@
 package com.showhive.performance.domain;
 
 import com.showhive.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +22,7 @@ public class Venue extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "venue_id")
     private Long id;
 
     @NotBlank

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Venue.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Venue.java
@@ -1,0 +1,39 @@
+package com.showhive.performance.domain;
+
+import com.showhive.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "venues")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Venue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String name;
+
+    private String address;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String contactNumber;
+
+    @NotBlank
+    private String link;
+}

--- a/showhive-data/data/src/main/java/com/showhive/performance/domain/Venue.java
+++ b/showhive-data/data/src/main/java/com/showhive/performance/domain/Venue.java
@@ -10,14 +10,16 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(name = "venues")
 @Entity
 @Getter
-@Table(name = "venues")
-@AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Venue extends BaseEntity {
 
     @Id

--- a/showhive-data/data/src/main/java/com/showhive/reservation/domain/Reservation.java
+++ b/showhive-data/data/src/main/java/com/showhive/reservation/domain/Reservation.java
@@ -2,6 +2,7 @@ package com.showhive.reservation.domain;
 
 import com.showhive.BaseEntity;
 import com.showhive.member.domain.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -24,6 +25,7 @@ public class Reservation extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/showhive-data/data/src/main/java/com/showhive/reservation/domain/Reservation.java
+++ b/showhive-data/data/src/main/java/com/showhive/reservation/domain/Reservation.java
@@ -1,7 +1,9 @@
 package com.showhive.reservation.domain;
 
 import com.showhive.BaseEntity;
+import com.showhive.code.domain.Code;
 import com.showhive.member.domain.Member;
+import com.showhive.performance.domain.PerformanceSession;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,14 +15,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(name = "reservations")
 @Entity
 @Getter
-@Table(name = "reservations")
-@AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation extends BaseEntity {
 
     @Id
@@ -32,13 +36,11 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    // TODO: Code 연결
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "code_id")
-//    private Code reservationStatusCode;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "code_id")
+    private Code reservationStatusCode;
 
-    // TODO: PerformanceSession 연결
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "session_id")
-//    private PerformanceSession performanceSession;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private PerformanceSession performanceSession;
 }

--- a/showhive-data/data/src/main/java/com/showhive/reservation/domain/Reservation.java
+++ b/showhive-data/data/src/main/java/com/showhive/reservation/domain/Reservation.java
@@ -1,6 +1,7 @@
-package com.showhive.performance.domain;
+package com.showhive.reservation.domain;
 
 import com.showhive.BaseEntity;
+import com.showhive.member.domain.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -14,34 +15,28 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
-@Table(name = "performance_seats")
+@Table(name = "reservations")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PerformanceSeat extends BaseEntity {
+public class Reservation extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-// TODO: PerformanceSession 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    // TODO: Code 연결
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "code_id")
+//    private Code reservationStatusCode;
+
+    // TODO: PerformanceSession 연결
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    @JoinColumn(name = "session_id")
 //    private PerformanceSession performanceSession;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seat_id")
-    private Seat seat;
-
-// TODO: Code 연결
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "code_id")
-//    private Code seatStatusCode;
-
-    private int price;
-
-    private LocalDateTime holdExpiresAt;
 }

--- a/showhive-data/data/src/main/java/com/showhive/reservation/domain/ReservationItem.java
+++ b/showhive-data/data/src/main/java/com/showhive/reservation/domain/ReservationItem.java
@@ -1,0 +1,41 @@
+package com.showhive.reservation.domain;
+
+import com.showhive.BaseEntity;
+import com.showhive.performance.domain.PerformanceSeat;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "reservation_items")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id")
+    private Reservation reservation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id")
+    private PerformanceSeat performanceSeat;
+
+    // TODO: PerformanceSession 연결
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "session_id")
+//    private PerformanceSession performanceSession;
+}

--- a/showhive-data/data/src/main/java/com/showhive/reservation/domain/ReservationItem.java
+++ b/showhive-data/data/src/main/java/com/showhive/reservation/domain/ReservationItem.java
@@ -13,14 +13,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(name = "reservation_items")
 @Entity
 @Getter
-@Table(name = "reservation_items")
-@AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationItem extends BaseEntity {
 
     @Id

--- a/showhive-data/data/src/main/java/com/showhive/reservation/domain/ReservationItem.java
+++ b/showhive-data/data/src/main/java/com/showhive/reservation/domain/ReservationItem.java
@@ -2,6 +2,7 @@ package com.showhive.reservation.domain;
 
 import com.showhive.BaseEntity;
 import com.showhive.performance.domain.PerformanceSeat;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -24,6 +25,7 @@ public class ReservationItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_item_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 📃 관련 이슈
- close #11

## ✨ 변경 내용
- 예매 관련 엔티티 클래스 추가

## 🔎 참고 사항 (선택)
- `Seat`테이블 내 column, row는 MYSQL에서 예약어라 백틱(`)으로 감싸주었습니다.
- 공연 관련 클래스들은 아직 추가가 안되어 있어 todo로 주석 처리 해두었습니다.
- `@OneToMany(mappedBy)`는 일단 사용하지 않았습니다.
우선 단방향 `@ManyToOne`만으로 관계를 표현했으며, 추후 부모 엔티티에서 자식 컬렉션을 직접 관리할 필요가 생긴다면 그 때`@OneToMany(mappedBy)`를 추가하는 것이 좋을 것 같은데, 어떻게 생각하시나요??


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 공연장(Venue) 정보 관리 추가: 이름, 주소, 좌표, 연락처, 링크 가능.
  * 좌석(Seat) 관리 추가: 열/행/층, 좌석 유형 등 세부 정보 포함.
  * 공연 좌석(PerformanceSeat) 추가: 좌석별 가격 및 보류 만료 시간 지원.
  * 예약(Reservation) 및 예약 항목(ReservationItem) 추가: 예약과 좌석 연결 처리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->