### PR TITLE
feat : 소셜 로그인 기능 구현

### DIFF
--- a/showhive-boot/boot/build.gradle
+++ b/showhive-boot/boot/build.gradle
@@ -5,11 +5,18 @@ jar { enabled = false }
 
 dependencies {
 
+
     implementation project(':showhive-data:data')
     implementation project(':showhive-infra:infra-persistence')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 직렬화
 
     // DB
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/api/AuthController.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/api/AuthController.java
@@ -1,0 +1,82 @@
+package com.showhive.auth.api;
+
+import com.showhive.auth.api.dto.LoginResponse;
+import com.showhive.auth.api.dto.SocialLoginRequest;
+import com.showhive.auth.application.SocialLoginUseCase;
+import com.showhive.auth.application.LogoutUseCase;
+import com.showhive.auth.application.RefreshTokenUseCase;
+import com.showhive.auth.application.command.LoginResultCommand;
+import com.showhive.auth.application.command.SocialLoginCommand;
+import com.showhive.member.domain.SocialInfo.Provider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final SocialLoginUseCase socialLoginUseCase;
+    private final RefreshTokenUseCase refreshTokenUseCase;
+    private final LogoutUseCase logoutUseCase;
+
+    // 단일 엔드포인트: /api/auth/{provider}  (google|kakao|naver)
+    @PostMapping("/{provider}")
+    public ResponseEntity<LoginResponse> login(
+            @PathVariable String provider,
+            @RequestBody SocialLoginRequest body,
+            HttpServletResponse resp) {
+
+        SocialLoginCommand command = new SocialLoginCommand(
+                Provider.valueOf(provider.toUpperCase()),
+                body.code(),
+                body.state()
+        );
+
+        LoginResultCommand result = socialLoginUseCase.login(command);
+
+        // refresh 쿠키 설정 (HTTP concern)
+        Cookie cookie = new Cookie("refreshToken", result.refreshToken());
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(7 * 24 * 60 * 60);
+        resp.addCookie(cookie);
+
+        return ResponseEntity.ok(new LoginResponse(result.accessToken(), null));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(HttpServletRequest request) {
+        String refreshToken = null;
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) { refreshToken = cookie.getValue(); }
+            }
+        }
+        LoginResponse response = refreshTokenUseCase.refresh(refreshToken);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization,
+                                       HttpServletResponse response) {
+        logoutUseCase.logout(authorization);
+
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/LoginRequest.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.showhive.auth.api.dto;
+
+public record LoginRequest(
+
+        String email,
+        String password
+
+) {
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/LoginResponse.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/LoginResponse.java
@@ -1,0 +1,6 @@
+package com.showhive.auth.api.dto;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/SignUpRequest.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/SignUpRequest.java
@@ -1,0 +1,25 @@
+package com.showhive.auth.api.dto;
+
+import com.showhive.auth.application.command.SignUpCommand;
+import com.showhive.member.application.command.MemberSignUpCommand;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+
+// 자체 회원가입
+public record SignUpRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password,
+        String name,
+        String role
+) {
+        public SignUpCommand toCommand() {
+                return new SignUpCommand(email, password, username, name,role);
+        }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/SocialLoginRequest.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/api/dto/SocialLoginRequest.java
@@ -1,0 +1,6 @@
+package com.showhive.auth.api.dto;
+
+public record SocialLoginRequest(
+        String code,
+        String state
+) {}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/LocalLoginUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/LocalLoginUseCase.java
@@ -1,0 +1,45 @@
+package com.showhive.auth.application;
+
+import com.showhive.auth.api.dto.LoginRequest;
+import com.showhive.auth.api.dto.LoginResponse;
+import com.showhive.config.util.JwtTokenProvider;
+import com.showhive.member.domain.Member;
+import com.showhive.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LocalLoginUseCase {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 자체 로그인
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        Member member = memberRepository
+                .findByEmailIgnoreCaseAndPasswordIsNotNull(request.email())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 이메일입니다."));
+
+        if (member.getPassword() == null) {
+            throw new IllegalStateException("소셜 계정은 비밀번호로 로그인할 수 없습니다.");
+        }
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getUsername(), member.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getUsername());
+
+        member.makeRefreshToken(refreshToken);
+        memberRepository.login(member);
+
+        return new LoginResponse(accessToken, refreshToken);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/LocalSignUpUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/LocalSignUpUseCase.java
@@ -1,0 +1,40 @@
+package com.showhive.auth.application;
+
+import com.showhive.auth.application.command.SignUpCommand;
+import com.showhive.member.domain.Member;
+import com.showhive.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LocalSignUpUseCase {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 예시
+    //    public void signUp(MemberSignUpCommand command) {
+    //        Member member = Member.create(command.name());
+    //        Member member = command.toDomain();
+    //        memberRepository.signUp(member);
+    //    }
+
+    // 회원가입
+    @Transactional
+    public void signUp(SignUpCommand command) {
+
+        memberRepository.findByEmailIgnoreCase(command.email())
+                .ifPresent(user -> {
+                    throw new IllegalStateException("이미 가입된 이메일입니다.");
+                });
+
+        String encoded = passwordEncoder.encode(command.password());
+        Member member = command.toDomain(encoded);
+        memberRepository.signUp(member);
+    }
+
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/LogoutUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/LogoutUseCase.java
@@ -1,0 +1,29 @@
+package com.showhive.auth.application;
+
+import com.showhive.config.util.JwtTokenProvider;
+import com.showhive.member.domain.Member;
+import com.showhive.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LogoutUseCase {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public void logout(String accessToken) {
+        String token = accessToken.replace("Bearer ", "");
+        String username = jwtTokenProvider.getUsernameFromToken(token);
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        member.deleteRefreshToken(); // 서버에 저장된 refreshToken 제거
+
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/RefreshTokenUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/RefreshTokenUseCase.java
@@ -1,0 +1,33 @@
+package com.showhive.auth.application;
+
+import com.showhive.auth.api.dto.LoginResponse;
+import com.showhive.config.util.JwtTokenProvider;
+import com.showhive.member.domain.Member;
+import com.showhive.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenUseCase {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    public LoginResponse refresh(String refreshTokenFromCookie) {
+
+        // 유효성 검사 + 사용자 식별
+        String username = jwtTokenProvider.getUsernameFromToken(refreshTokenFromCookie);
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        if (!refreshTokenFromCookie.equals(member.getRefreshToken())) {
+            throw new SecurityException("서버에 저장된 리프레시 토큰과 다릅니다.");
+        }    // 서버 저장본과 동일한지 확인 (토큰 탈취 방지)
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(username, member.getRole());
+        return new LoginResponse(newAccessToken, null); // 쿠키에서 꺼낸 refreshToken을 추출해서 검증 후 새 AccessToken 발급
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/SocialLoginUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/SocialLoginUseCase.java
@@ -1,0 +1,76 @@
+package com.showhive.auth.application;
+
+import com.showhive.auth.application.command.LoginResultCommand;
+import com.showhive.auth.application.command.SocialLoginCommand;
+import com.showhive.auth.application.command.SocialUpsertCommand;
+import com.showhive.auth.oauth.OAuthGateway;
+import com.showhive.auth.oauth.SocialProfileDto;
+import com.showhive.config.util.JwtTokenProvider;
+import com.showhive.member.domain.Member;
+import com.showhive.member.domain.SocialInfo;
+import com.showhive.member.repository.MemberRepository;
+import com.showhive.member.repository.SocialInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SocialLoginUseCase {
+
+    private final OAuthGateway oAuth;                    // infra (토큰/유저조회)
+    private final MemberRepository memberRepository;     // data 포트
+    private final SocialInfoRepository socialInfoRepository; // data 포트
+    private final JwtTokenProvider jwt;
+
+    public LoginResultCommand login(SocialLoginCommand command) {
+        // 1) code -> access token
+        String accessToken = oAuth.exchangeCodeForAccessToken(command.provider(), command.code(), command.stateOrNull());
+
+        // 2) token -> profile
+        SocialProfileDto profile = oAuth.fetchProfile(command.provider(), accessToken);
+
+        // 3) upsert
+        Member member = socialInfoRepository
+                .findByProviderAndProviderUserId(profile.provider(), profile.providerId())
+                .map(social -> {
+                    social.updateProfile(profile.email(), profile.name());
+                    Member info = social.getMember();
+                    info.mergeProfileFromSocial(profile.name(), profile.email());
+                    return info;
+                })
+                .orElseGet(() -> {
+                    Member existing = (profile.email() != null)
+                            ? memberRepository.findByEmailIgnoreCase(profile.email()).orElse(null)
+                            : null;
+
+                    if (existing == null) {
+                        // 신규 회원 생성 (업서트 커맨드 사용해 toDomain)
+                        Member newMember = new SocialUpsertCommand(
+                                profile.provider(), profile.providerId(), profile.email(), profile.name()
+                        ).toDomain();
+
+                        SocialInfo socialInfo = SocialInfo.of(profile.provider(), profile.providerId(), profile.email(), profile.name());
+                        newMember.addSocialInfo(socialInfo);
+
+                        return memberRepository.save(newMember);
+                    } else {
+                        existing.mergeProfileFromSocial(profile.name(), profile.email());
+                        SocialInfo s = SocialInfo.of(profile.provider(), profile.providerId(), profile.email(), profile.name());
+                        existing.addSocialInfo(s);
+                        return memberRepository.save(existing);
+                    }
+                });
+
+        // 4) 토큰 발급 및 저장
+        String newAccessToken = jwt.generateAccessToken(member.getUsername(), member.getRole());
+        String refreshToken = jwt.generateRefreshToken(member.getUsername());
+        member.makeRefreshToken(refreshToken);
+        memberRepository.save(member);
+
+        return new LoginResultCommand(member.getId(), member.getUsername(), newAccessToken, refreshToken);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/LoginResultCommand.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/LoginResultCommand.java
@@ -1,0 +1,9 @@
+package com.showhive.auth.application.command;
+
+public record LoginResultCommand(
+        Long userId,
+        String username,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/SignUpCommand.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/SignUpCommand.java
@@ -1,0 +1,23 @@
+package com.showhive.auth.application.command;
+
+import com.showhive.member.domain.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignUpCommand(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password,
+        String name,
+        String role
+) {
+    public Member toDomain(String encodedPassword) {
+        String username = email; // 정책: username = email
+        return Member.signUp(email, password, username, name, encodedPassword);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/SocialLoginCommand.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/SocialLoginCommand.java
@@ -1,0 +1,13 @@
+package com.showhive.auth.application.command;
+
+import com.showhive.member.domain.SocialInfo.Provider;
+
+// 요청용 커맨드
+public record SocialLoginCommand(
+        Provider provider,
+        String code,
+        String stateOrNull
+
+) {
+
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/SocialUpsertCommand.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/application/command/SocialUpsertCommand.java
@@ -1,0 +1,15 @@
+package com.showhive.auth.application.command;
+
+import com.showhive.member.domain.Member;
+import com.showhive.member.domain.SocialInfo.Provider;
+
+public record SocialUpsertCommand(
+        Provider provider,
+        String providerUserId,
+        String email,
+        String name
+) {
+    public Member toDomain() {
+        return Member.signUpSocial(provider, providerUserId, email, name);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/GoogleOAuthClient.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/GoogleOAuthClient.java
@@ -1,0 +1,80 @@
+package com.showhive.auth.oauth;
+
+import com.showhive.member.domain.SocialInfo.Provider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOAuthClient {
+
+    private final RestTemplate rest;
+
+    @Value("${google.client-id}")
+    String clientId;
+    @Value("${google.client-secret}")
+    String clientSecret;
+    @Value("${google.redirect-uri}")
+    String redirectUri;
+
+    // 인가 코드로 액세스 토큰 교환
+    public String exchangeCode(String code) {
+        String tokenUrl = "https://oauth2.googleapis.com/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(params, headers);
+        Map<String, Object> body = rest.postForObject(tokenUrl, req, Map.class);
+
+        if (body == null || body.get("access_token") == null) {
+            throw new IllegalStateException("Google access token 응답 없음");
+        }
+        return (String) body.get("access_token");
+    }
+
+    //  액세스 토큰으로 사용자 정보 조회
+    public SocialProfileDto fetchProfile(String accessToken) {
+        String url = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> req = new HttpEntity<>(headers);
+        ResponseEntity<Map> res = rest.exchange(url, HttpMethod.GET, req, Map.class);
+        Map userInfo = res.getBody();
+
+        if (userInfo == null) {
+            throw new IllegalStateException("Google 사용자 정보 조회 실패");
+        }
+
+        String id = String.valueOf(userInfo.get("id"));
+        String email = (String) userInfo.get("email");
+        String name = (String) userInfo.get("name");
+
+        if (name == null) {
+            String given = (String) userInfo.get("given_name");
+            String family = (String) userInfo.get("family_name");
+            name = (given != null ? given : "") + (family != null ? " " + family : "");
+        }
+
+        return new SocialProfileDto(Provider.GOOGLE, id, email, name);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/KakaoOAuthClient.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/KakaoOAuthClient.java
@@ -1,0 +1,85 @@
+package com.showhive.auth.oauth;
+
+import com.showhive.member.domain.SocialInfo.Provider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+    private final RestTemplate rest;
+
+    @Value("${kakao.client-id}")
+    String clientId;
+    @Value("${kakao.redirect-uri}")
+    String redirectUri;
+
+
+    // 인가 코드로 액세스 토큰 교환
+    public String exchangeCode(String code) {
+        String tokenUrl = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(params, headers);
+        Map<String, Object> body = rest.postForObject(tokenUrl, req, Map.class);
+
+        if (body == null || body.get("access_token") == null) {
+            throw new IllegalStateException("Kakao access token 응답 없음");
+        }
+        return (String) body.get("access_token");
+    }
+
+    // 액세스 토큰으로 사용자 정보 조회
+    public SocialProfileDto fetchProfile(String accessToken) {
+        String url = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> req = new HttpEntity<>(headers);
+        ResponseEntity<Map> res = rest.exchange(url, HttpMethod.GET, req, Map.class);
+        Map<String, Object> body = res.getBody();
+
+        if (body == null) {
+            throw new IllegalStateException("Kakao 사용자 정보 조회 실패");
+        }
+
+        String id = String.valueOf(body.get("id"));
+        Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+
+        String email = null;
+        String name = null;
+
+        if (kakaoAccount != null) {
+            email = (String) kakaoAccount.get("email");
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+            if (profile != null) {
+                name = (String) profile.get("nickname");
+            }
+            if (name == null) {
+                name = (String) kakaoAccount.get("name");
+            }
+        }
+
+        return new SocialProfileDto(Provider.KAKAO, id, email, name);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/NaverOAuthClient.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/NaverOAuthClient.java
@@ -1,0 +1,77 @@
+package com.showhive.auth.oauth;
+
+import com.showhive.member.domain.SocialInfo.Provider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class NaverOAuthClient {
+    private final RestTemplate rest;
+    @Value("${naver.client-id}")
+    String clientId;
+    @Value("${naver.client-secret}")
+    String clientSecret;
+    @Value("${naver.redirect-uri}")
+    String redirectUri;
+
+    // 인가 코드로 액세스 토큰 교환
+    public String exchangeCode(String code, String state) {
+        String tokenUrl = "https://nid.naver.com/oauth2.0/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("code", code);
+        params.add("state", state);
+
+        HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(params, headers);
+        Map<String, Object> body = rest.postForObject(tokenUrl, req, Map.class);
+
+        if (body == null || body.get("access_token") == null) {
+            throw new IllegalStateException("Naver access token 응답 없음");
+        }
+        return (String) body.get("access_token");
+    }
+
+    // 액세스 토큰으로 사용자 정보 조회
+    public SocialProfileDto fetchProfile(String accessToken) {
+        String url = "https://openapi.naver.com/v1/nid/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> req = new HttpEntity<>(headers);
+        ResponseEntity<Map> res = rest.exchange(url, HttpMethod.GET, req, Map.class);
+        Map<String, Object> body = res.getBody();
+
+        if (body == null) {
+            throw new IllegalStateException("Naver 사용자 정보 조회 실패");
+        }
+
+        Map<String, Object> response = (Map<String, Object>) body.get("response");
+        if (response == null) {
+            throw new IllegalStateException("Naver 사용자 정보 구조 오류");
+        }
+
+        String id = (String) response.get("id");
+        String email = (String) response.get("email");
+        String name = (String) response.get("name");
+
+        return new SocialProfileDto(Provider.NAVER, id, email, name);
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/OAuthGateway.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/OAuthGateway.java
@@ -1,0 +1,35 @@
+package com.showhive.auth.oauth;
+
+import com.showhive.member.domain.SocialInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthGateway {
+
+    private final GoogleOAuthClient google;
+    private final KakaoOAuthClient kakao;
+    private final NaverOAuthClient naver;
+
+    //  인가 코드 → 액세스 토큰
+    public String exchangeCodeForAccessToken(SocialInfo.Provider p, String code, String stateOrNull) {
+        return switch (p) {
+            case GOOGLE -> google.exchangeCode(code);
+            case KAKAO  -> kakao.exchangeCode(code);
+            case NAVER  -> naver.exchangeCode(code, stateOrNull);
+        };
+    }
+
+    // 액세스 토큰 → 외부 사용자 정보
+    public SocialProfileDto fetchProfile(SocialInfo.Provider p, String accessToken) {
+        return switch (p) {
+            case GOOGLE -> google.fetchProfile(accessToken);
+            case KAKAO  -> kakao.fetchProfile(accessToken);
+            case NAVER  -> naver.fetchProfile(accessToken);
+        };
+    }
+}
+
+// 유스케이스는 외부 호출 세부사항을 몰라야 테스트가 쉬워짐.
+// 인터페이스 없이 구현 빈 하나(@Component)로 라우팅까지 처리해도 OK.

--- a/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/SocialProfileDto.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/auth/oauth/SocialProfileDto.java
@@ -1,0 +1,12 @@
+package com.showhive.auth.oauth;
+
+
+import com.showhive.member.domain.SocialInfo.Provider;
+
+public record SocialProfileDto(
+        Provider provider,
+        String providerId,
+        String email,
+        String name
+) {
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/config/HttpClientConfig.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/config/HttpClientConfig.java
@@ -1,0 +1,13 @@
+package com.showhive.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/config/SecurityConfig.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.showhive.config;
+
+
+import com.showhive.config.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+
+    // 권한 기반 인가 설정
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)      // REST API에서는 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 로그인 페이지 비활성화
+                .httpBasic(Customizer.withDefaults())  // JWT 등 다른 인증 방식 사용
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll() // 회원가입한 경우, 인증 안되어있어도 접근가능
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("api/private/**").hasAnyRole("USER", "ADMIN")
+                        .anyRequest().denyAll()) // 기본 인증 (jwt로 대체)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    // 비밀번호 단방향(BCrypt) 암호화용 Bean
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOrigin("http://localhost:5173"); // 프론트 주소
+        config.addAllowedMethod("*"); // GET, POST, PUT, DELETE 등
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true); // 인증 정보 (쿠키, 헤더 등) 포함 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/config/security/CustomUserDetailsService.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/config/security/CustomUserDetailsService.java
@@ -1,0 +1,4 @@
+package com.showhive.config.security;
+
+public class CustomUserDetailsService {
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/config/security/JwtAuthenticationFilter.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.showhive.config.security;
+
+import com.showhive.config.util.JwtTokenProvider;
+import com.showhive.member.domain.Member;
+import com.showhive.member.repository.MemberRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+// jwt 인증 필터
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final UserDetailsService userDetailsService; // jwt 필터에서 인증 정보 반영
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            String username = jwtTokenProvider.getUsernameFromToken(token);
+            Member member = memberRepository.findByUsername(username).orElse(null);
+
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username); // 추가
+
+            if (member != null) {
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/config/util/JwtTokenProvider.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/config/util/JwtTokenProvider.java
@@ -1,0 +1,67 @@
+package com.showhive.config.util;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256); // 랜덤 키
+    private final long expiration = 1000L * 60 * 60; // 만료시간 : 1시간
+
+    // 토큰 생성 함수 (랜덤키 사용해서 토큰 발급)
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(key)
+                .compact();
+    }
+
+    // 로그인 AccessToken
+    public String generateAccessToken(String username, String role) {
+        long expiration_30m = 1000L * 60 * 60; // 30분
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("role", role)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration_30m)) // 30분
+                .signWith(key)
+                .compact();
+    }
+
+    // 로그인 RefreshToken
+    public String generateRefreshToken(String username) {
+        long expiration_7d = 1000L * 60 * 60 * 24 * 7; // 7일
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration_7d)) // 7일
+                .signWith(key)
+                .compact();
+    }
+
+
+    public String getUsernameFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/showhive-boot/boot/src/main/java/com/showhive/member/api/MemberController.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/member/api/MemberController.java
@@ -1,16 +1,6 @@
 package com.showhive.member.api;
 
-import com.showhive.member.api.dto.MemberResponse;
-import com.showhive.member.api.dto.MemberSignUpRequest;
-import com.showhive.member.application.MemberFindUseCase;
-import com.showhive.member.application.MemberSignUpUseCase;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,18 +9,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberSignUpUseCase memberSignUpUseCase;
-    private final MemberFindUseCase memberFindUseCase;
-
-    @PostMapping
-    public ResponseEntity<Void> createMember(@RequestBody @Valid MemberSignUpRequest request) {
-        memberSignUpUseCase.signUp(request.toCommand());
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/{memberId}")
-    public ResponseEntity<MemberResponse> findMember(@PathVariable long memberId) {
-        MemberResponse response = memberFindUseCase.findMember(memberId);
-        return ResponseEntity.ok(response);
-    }
+//    private final MemberSignUpUseCase memberSignUpUseCase;
+//    private final MemberFindUseCase memberFindUseCase;
+//
+//    @PostMapping
+//    public ResponseEntity<Void> createMember(@RequestBody @Valid MemberSignUpRequest request) {
+//        memberSignUpUseCase.signUp(request.toCommand());
+//        return ResponseEntity.ok().build();
+//    }
+//
+//    @GetMapping("/{memberId}")
+//    public ResponseEntity<MemberResponse> findMember(@PathVariable long memberId) {
+//        MemberResponse response = memberFindUseCase.findMember(memberId);
+//        return ResponseEntity.ok(response);
+//    }
 }

--- a/showhive-boot/boot/src/main/java/com/showhive/member/api/dto/MemberSignUpRequest.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/member/api/dto/MemberSignUpRequest.java
@@ -5,7 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 
 public record MemberSignUpRequest(
         @NotBlank
-        String name
+        String email,
+        String username,
+        String password,
+        String name,
+        String role
 ) {
     public MemberSignUpCommand toCommand() {
         return new MemberSignUpCommand(name);

--- a/showhive-boot/boot/src/main/java/com/showhive/member/application/MemberFindUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/member/application/MemberFindUseCase.java
@@ -14,9 +14,9 @@ public class MemberFindUseCase {
 
     private final MemberRepository memberRepository;
 
-    public MemberResponse findMember(long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-        return MemberResponse.from(member);
-    }
+//    public MemberResponse findMember(long memberId) {
+//        Member member = memberRepository.findById(memberId)
+//                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+//        return MemberResponse.from(member);
+//    }
 }

--- a/showhive-boot/boot/src/main/java/com/showhive/member/application/MemberSignUpUseCase.java
+++ b/showhive-boot/boot/src/main/java/com/showhive/member/application/MemberSignUpUseCase.java
@@ -6,15 +6,15 @@ import com.showhive.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class MemberSignUpUseCase {
-
-    private final MemberRepository memberRepository;
-
-    public void signUp(MemberSignUpCommand command) {
-        Member member = Member.create(command.name());
-//        Member member = command.toDomain();
-        memberRepository.signUp(member);
-    }
-}
+//@Service
+//@RequiredArgsConstructor
+//public class MemberSignUpUseCase {
+//
+//    private final MemberRepository memberRepository;
+//
+//    public void signUp(MemberSignUpCommand command) {
+//        Member member = Member.create(command.name());
+////        Member member = command.toDomain();
+//        memberRepository.signUp(member);
+//    }
+//}

--- a/showhive-boot/boot/src/main/resources/application.yml
+++ b/showhive-boot/boot/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: boot-member
   datasource:
-    url: jdbc:mysql://localhost:3306/testdb?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/showhive_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
@@ -15,6 +15,21 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: http://localhost:5173/oauth2/redirect/kakao
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
+  redirect-uri: http://localhost:5173/oauth2/redirect/google
+
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+  redirect-uri: http://localhost:5173/oauth2/redirect/naver
+
 
 pringdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/showhive-data/data/src/main/java/com/showhive/member/domain/Member.java
+++ b/showhive-data/data/src/main/java/com/showhive/member/domain/Member.java
@@ -1,37 +1,125 @@
 package com.showhive.member.domain;
 
 import com.showhive.BaseEntity;
+import com.showhive.member.domain.SocialInfo.Provider;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
-@Table
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "members",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_username", columnNames = "username"),
+                @UniqueConstraint(name = "uk_member_email", columnNames = "email")
+        }
+)
 public class Member extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    //앱 내부 식별용 아이디(표시명 아님). 소셜이면 kakao_123 처럼 부여
+    @Column(nullable = false, length = 100)
+    private String username;
+
+    // 로컬 로그인만 사용. 소셜 사용자는 null 가능
+    @Column(length = 100)
+    private String password;
+
+    // 사용자 실명 또는 닉네임(정책에 맞게 사용)
+    @Column(length = 100)
     private String name;
 
-    protected Member() {
+    @Column(length = 255)
+    private String email;
+
+    @Column(nullable = false, length = 20)
+    private String role; // 예: ROLE_USER, ROLE_ADMIN
+
+    @Column(length = 500)
+    private String refreshToken;
+
+    // 소셜 계정 목록 (1:N)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<SocialInfo> socialInfos = new ArrayList<>();
+
+    // 소셜 프로필 정보로 사용자 프로필을 병합 (이메일/이름이 비어있거나 다르면 갱신)
+    public void mergeProfileFromSocial(String name, String email) {
+        if (email != null && (this.email == null || !this.email.equalsIgnoreCase(email))) {
+            this.email = email;
+        }
+        if (name != null && (this.name == null || !this.name.equals(name))) {
+            this.name = name;
+        }
     }
 
-    private Member(String name) {
-        this.name = name;
+    public void addSocialInfo(SocialInfo social_Info) {
+        if (social_Info == null) {
+            return;
+        }
+        social_Info.attachTo(this); // 소유자 연결
+        if (!this.socialInfos.contains(social_Info)) {
+            this.socialInfos.add(social_Info);
+        }
     }
 
-    public static Member create(String name) {
-        return new Member(name);
+    public static Member signUp(String email, String password, String username, String name, String encodedPassword) {
+        return Member.builder()
+                .email(email)
+                .username(username)  // username을 이메일 기반으로 지정
+                .password(encodedPassword)
+                .name(name)
+                .role("ROLE_USER")
+                .build();
     }
 
-    public Long getId() {
-        return id;
+    public static Member signUpSocial(Provider provider, String providerUserId, String email, String name) {
+        if (provider == null) {
+            throw new IllegalArgumentException("provider 불가");
+        }
+        if (providerUserId == null || providerUserId.isBlank()) {
+            throw new IllegalArgumentException("providerUserId 불가");
+        }
+
+        String username = provider.name().toLowerCase() + "_" + providerUserId;
+        return Member.builder()
+                .email(email)
+                .username(username)
+                .password(null)
+                .role("ROLE_USER")
+                .build();
     }
 
-    public String getName() {
-        return name;
+    // 리프레시 토큰 발급/갱신
+    public void makeRefreshToken(String newToken) {
+        if (newToken == null || newToken.isBlank()) {
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰");
+        }
+
+        this.refreshToken = newToken;
+    }
+
+    // 토큰 폐기 (로그아웃/강제만료)
+    public void deleteRefreshToken() {
+        this.refreshToken = null;
     }
 }

--- a/showhive-data/data/src/main/java/com/showhive/member/domain/SocialInfo.java
+++ b/showhive-data/data/src/main/java/com/showhive/member/domain/SocialInfo.java
@@ -1,0 +1,95 @@
+package com.showhive.member.domain;
+
+import com.showhive.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "social_infos", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_provider_pid", columnNames = {"provider", "provider_user_id"})
+},
+        indexes = {
+                @Index(name = "idx_social_user", columnList = "user_id")})
+public class SocialInfo extends BaseEntity {
+
+    public enum Provider {GOOGLE, KAKAO, NAVER}
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long social_id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Provider provider;                  // GOOGLE/KAKAO/NAVER
+
+    @Column(name = "provider_user_id", nullable = false, length = 100)
+    private String providerUserId;              // 소셜의 고유 ID (예: kakao id)
+
+    @Column(length = 255)
+    private String email;                       // 소셜이 준 이메일(동의 없으면 null)
+
+    @Column(length = 100)
+    private String nickname;                    // 소셜 닉네임/이름
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    public static SocialInfo of(Provider provider, String providerUserId, String email,
+                                String nickname) {
+        if (provider == null) {
+            throw new IllegalArgumentException("provider 불가");
+        }
+
+        if (providerUserId == null || providerUserId.isBlank()) {
+            throw new IllegalArgumentException("providerUserId 불가");
+        }
+
+        return SocialInfo.builder()
+                .provider(provider)
+                .providerUserId(providerUserId)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
+
+    //소셜 프로필 갱신 (이메일/닉네임이 비어있거나 다르면 갱신)
+    public void updateProfile(String email, String nickname) {
+        if (email != null && (this.email == null || !this.email.equalsIgnoreCase(email))) {
+            this.email = email;
+        }
+        if (nickname != null && (this.nickname == null || !this.nickname.equals(nickname))) {
+            this.nickname = nickname;
+        }
+    }
+
+    //소유자 연결
+    public void attachTo(Member owner) {
+        this.member = owner;
+    }
+
+    // 소유자 해제
+    public void detach() {
+        this.member = null;
+    }
+
+}

--- a/showhive-data/data/src/main/java/com/showhive/member/repository/MemberRepository.java
+++ b/showhive-data/data/src/main/java/com/showhive/member/repository/MemberRepository.java
@@ -6,6 +6,23 @@ import java.util.Optional;
 
 public interface MemberRepository {
     void signUp(Member member);
+    void login(Member member);
 
-    Optional<Member> findById(long memberId);
+    Member save(Member member);
+
+    Optional<Member> findByUsername(String username);
+
+    //  로컬 로그인용: 이메일 + (비번이 null이 아닌 계정)
+    Optional<Member> findByEmailAndPasswordIsNotNull(String email);
+
+    // 회원가입 중복 체크용(정책에 따라 이메일 전체 중복 차단)
+    Optional<Member> findByEmailIgnoreCase(String email);
+
+    // 로그인 조회용(로컬만)
+    Optional<Member> findByEmailIgnoreCaseAndPasswordIsNotNull(String email);
+
+    // 이메일로 기존 사용자 찾고 소셜 계정 attach  - 회원가입 중복 체크
+    Optional<Member> findByEmail(String email);
+
+
 }

--- a/showhive-data/data/src/main/java/com/showhive/member/repository/SocialInfoRepository.java
+++ b/showhive-data/data/src/main/java/com/showhive/member/repository/SocialInfoRepository.java
@@ -1,0 +1,14 @@
+package com.showhive.member.repository;
+
+
+import com.showhive.member.domain.SocialInfo;
+import com.showhive.member.domain.SocialInfo.Provider;
+import java.util.Optional;
+
+public interface SocialInfoRepository {
+
+    Optional<SocialInfo> findByProviderAndProviderUserId(
+            Provider provider, String providerUserId);
+
+
+}

--- a/showhive-infra/infra-import/build.gradle
+++ b/showhive-infra/infra-import/build.gradle
@@ -4,5 +4,9 @@ bootJar { enabled = true }
 jar { enabled = false }
 
 dependencies {
+
+    implementation project(':showhive-data:data')
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/showhive-infra/infra-persistence/src/main/java/com/showhive/member/JpaMemberRepository.java
+++ b/showhive-infra/infra-persistence/src/main/java/com/showhive/member/JpaMemberRepository.java
@@ -1,7 +1,19 @@
 package com.showhive.member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.showhive.member.domain.Member;
 
 public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+
+
+    Optional<Member> findByUsername(String username);
+
+    Optional<Member> findByEmailAndPasswordIsNotNull(String email);
+
+    Optional<Member> findByEmailIgnoreCase(String email);
+
+    Optional<Member> findByEmailIgnoreCaseAndPasswordIsNotNull(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/showhive-infra/infra-persistence/src/main/java/com/showhive/member/JpaSocialInfoRepository.java
+++ b/showhive-infra/infra-persistence/src/main/java/com/showhive/member/JpaSocialInfoRepository.java
@@ -1,0 +1,12 @@
+package com.showhive.member;
+
+import com.showhive.member.domain.SocialInfo;
+import com.showhive.member.domain.SocialInfo.Provider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaSocialInfoRepository extends JpaRepository<SocialInfo, Long> {
+
+    Optional<SocialInfo> findByProviderAndProviderUserId(Provider provider, String providerUserId);
+
+}

--- a/showhive-infra/infra-persistence/src/main/java/com/showhive/member/MemberRepositoryImpl.java
+++ b/showhive-infra/infra-persistence/src/main/java/com/showhive/member/MemberRepositoryImpl.java
@@ -14,14 +14,42 @@ public class MemberRepositoryImpl implements MemberRepository {
     private final JpaMemberRepository jpaMemberRepository;
 
     @Override
-    // TODO: 사용 안 할 시 삭제 예정
+    public Member save(Member member) {jpaMemberRepository.save(member); return member;}
+
+    @Override
     public void signUp(Member member) {
         jpaMemberRepository.save(member);
     }
 
     @Override
-    // TODO: 사용 안 할 시 삭제 예정
-    public Optional<Member> findById(long memberId) {
-        return jpaMemberRepository.findById(memberId);
+    public void login(Member member) {
+        jpaMemberRepository.save(member);
+    }
+
+    @Override
+    public Optional<Member> findByUsername(String username) {
+        return jpaMemberRepository.findByUsername(username);
+    }
+
+    @Override
+    public Optional<Member> findByEmailAndPasswordIsNotNull(String email) {
+        return jpaMemberRepository.findByEmailAndPasswordIsNotNull(email);
+    }
+
+    @Override
+    public Optional<Member> findByEmailIgnoreCase(String email) {
+        return jpaMemberRepository.findByEmailIgnoreCase(email);
+    }
+
+    @Override
+    public Optional<Member> findByEmailIgnoreCaseAndPasswordIsNotNull(String email) {
+        return jpaMemberRepository.findByEmailIgnoreCaseAndPasswordIsNotNull(email);
+    }
+
+    @Override
+    public Optional<Member> findByEmail(String email) {
+        return jpaMemberRepository.findByEmail(email);
     }
 }
+// 지금 MemberRepositoryImpl은 도메인 레이어(data)의 MemberRepository 포트를 구현하는 클래스
+// 내부적으로 Spring Data JPA 리포지토리(JpaMemberRepository)를 사용

--- a/showhive-infra/infra-persistence/src/main/java/com/showhive/member/SocialInfoRepositoryImpl.java
+++ b/showhive-infra/infra-persistence/src/main/java/com/showhive/member/SocialInfoRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.showhive.member;
+
+import com.showhive.member.domain.SocialInfo;
+import com.showhive.member.domain.SocialInfo.Provider;
+import com.showhive.member.repository.SocialInfoRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SocialInfoRepositoryImpl implements SocialInfoRepository {
+
+    private final JpaSocialInfoRepository jpaSocialInfoRepository;
+
+    @Override
+    public Optional<SocialInfo> findByProviderAndProviderUserId(
+            Provider provider, String providerUserId) {
+
+        return jpaSocialInfoRepository.findByProviderAndProviderUserId(provider, providerUserId);
+    }
+}


### PR DESCRIPTION
## 📃 관련 이슈
- close #7

## ✨ 변경 내용
- 모놀리식 구조에서 구현한 자체 회원가입, 로그인, 소셜로그인 기능을 멀티 모듈 프로젝트에 구현
- boot 모듈 속 application.yml 에 Mysql, Google, Kakao, Naver 환경변수 설정
- 소셜로그인은 잘 되지만 자체 회원가입, 로그인 기능 오류 발생해서 수정 필요
- 계속 코드 리펙토링할 예정

## 🔎 참고 사항 (선택)
- 리펙토링할 때 참고할 자료 : https://github.dev/woowacourse-teams/2024-ody
- UseCase가 기능별로 많아질 때 어떤식으로 정리할지 고민 중
- RestTemplate 대신 RestClient 활용하기 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 구글/카카오/네이버 소셜 로그인 추가 및 통합 인증 엔드포인트 제공
  - 이메일/비밀번호 기반 로그인·회원가입 지원
  - JWT 기반 인증 도입: 액세스 토큰 발급, 보안 쿠키를 통한 리프레시 토큰, 토큰 재발급·로그아웃 엔드포인트 제공
- Chores
  - 보안 및 검증 라이브러리 의존성 추가
  - CORS 설정(http://localhost:5173) 및 권한별 접근 규칙 구성(/api/auth 허용, /api/admin 관리자 전용 등)
  - DB 연결 URL을 showhive_db로 변경
- Refactor
  - 기존 회원 API 일부 비활성화(레거시 엔드포인트 정리)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->